### PR TITLE
Toolchain Updates / Maintenance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,16 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 29
+    buildToolsVersion "28.0.3"
     defaultConfig {
         applicationId 'com.ataulm.talkbacktile'
         minSdkVersion 24
-        targetSdkVersion 25
+        targetSdkVersion 29
         versionCode 2
         versionName "1.1"
     }
@@ -18,6 +18,7 @@ android {
     }
 
     dependencies {
-        compile 'com.novoda:accessibilitools:1.4.0'
+        implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+        implementation 'com.novoda:accessibilitools:1.4.0'
     }
 }

--- a/mobile/src/main/java/com/ataulm/talkbacktile/ToggleTalkBackTileService.java
+++ b/mobile/src/main/java/com/ataulm/talkbacktile/ToggleTalkBackTileService.java
@@ -21,9 +21,10 @@ import android.os.Handler;
 import android.os.Looper;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
-import android.support.annotation.DrawableRes;
 import android.util.Log;
 import android.widget.Toast;
+
+import androidx.annotation.DrawableRes;
 
 import com.novoda.accessibility.AccessibilityServices;
 


### PR DESCRIPTION
- Gradle → 5.4.1
- Gradle Plugin → 3.4.1
- Repositories += google()
- Support Libs → AndroidX
- Target & Compile Version → 29
- Build Tools → 28.0.3
- 'compile' in build.gradle → 'implementation'

Testing done:
- Compiles on a Linux system using a fresh copy of the latest Android tools
- Installs fine on an emulator running Pie
- After granting permission as described in README, successfully toggles Talkback